### PR TITLE
Fix QtoolTip headfile lose

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,8 @@
 kylin-video (2.1.0-4) unstable; urgency=medium
 
   * Put EnableHighDpiScaling and UseHighDpiPixmaps before MyApplication 
-
+  * Fix Playstop-Cursor-Not-Show and Engine-Swtich-Playlist-Add-File-Failed 
+ 
  -- zhaoyubiao <zhaoyubiao@kylinos.cn>  Fri, 07 Aug 2020 10:42:02 +0800
 
 kylin-video (2.1.0-3) unstable; urgency=medium

--- a/src/smplayer/prefgeneral.h
+++ b/src/smplayer/prefgeneral.h
@@ -25,6 +25,7 @@
 #include "../smplayer/inforeader.h"
 #include "../smplayer/deviceinfo.h"
 #include "../smplayer/preferences.h"
+#include <QToolTip>
 
 class PrefGeneral : public PrefWidget, public Ui::PrefGeneral
 {


### PR DESCRIPTION
Fix Playstop-Cursor-Not-Show and Engine-Swtich-Playlist-Add-File-Failed，Fix QtoolTip headfile lose