### PR TITLE
Fix build with Qt 5.15 again

### DIFF
--- a/src/systembutton.cpp
+++ b/src/systembutton.cpp
@@ -19,6 +19,7 @@
 
 #include "systembutton.h"
 #include <QDebug>
+#include <QPainterPath>
 
 SystemButton::SystemButton(QWidget *parent) :
     QPushButton(parent)


### PR DESCRIPTION
The new QPainterPath use that was added in 17ac4742a24b758d needs an include.